### PR TITLE
Version 2.2.1.3

### DIFF
--- a/com.bktus.gpgfrontend.yaml
+++ b/com.bktus.gpgfrontend.yaml
@@ -80,6 +80,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/saturneric/GpgFrontend.git
-        commit: 79356688abd289ab8cd2ed53129af383282efd1c
+        commit: e1171cb476a27cbbf7d93e32ee5328b128fcb9f4
 
       - cargo-sources.json


### PR DESCRIPTION
* Bump the pinned upstream git commit for `GpgFrontend` to pull in recent fixes and improvements.
* Ensures builds fetch and use the updated upstream source; no other manifest fields were changed.
* Recommend rebuilding packages to propagate the upstream updates.